### PR TITLE
Update logout to redirect to marketing site

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -165,6 +165,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     sessionStorage.removeItem('auth_token')
     setToken(null)
     setUser(null)
+    window.location.href = 'https://shinzo.ai'
   }
 
   const value = {


### PR DESCRIPTION
- Modified logout function in AuthContext to redirect to https://shinzo.ai
- Ensures seamless user flow from platform back to marketing site after logout
- Maintains user engagement by directing them to the main website

🤖 Generated with [Claude Code](https://claude.ai/code)