### PR TITLE
Add icon to top-left corner of Login and Register pages

### DIFF
--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -32,6 +32,25 @@ export const LoginPage: React.FC = () => {
 
   return (
     <div className="auth-page">
+      <a
+        href="https://shinzo.ai"
+        style={{
+          position: 'absolute',
+          top: '20px',
+          left: '20px',
+          textDecoration: 'none'
+        }}
+      >
+        <img
+          src="/ShinzoIcon512.png"
+          alt="Back to Shinzo"
+          style={{
+            width: '48px',
+            height: '48px',
+            cursor: 'pointer'
+          }}
+        />
+      </a>
       <Card size="4" style={{ maxWidth: '400px', width: '100%' }}>
         <Flex direction="column" gap="2">
           <Flex justify="center" align="center" style={{ width: '100%' }}>

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -78,6 +78,25 @@ export const RegisterPage: React.FC = () => {
   if (success) {
     return (
       <div className="auth-page">
+        <a
+          href="https://shinzo.ai"
+          style={{
+            position: 'absolute',
+            top: '20px',
+            left: '20px',
+            textDecoration: 'none'
+          }}
+        >
+          <img
+            src="/ShinzoIcon512.png"
+            alt="Back to Shinzo"
+            style={{
+              width: '48px',
+              height: '48px',
+              cursor: 'pointer'
+            }}
+          />
+        </a>
         <Card size="4" style={{ maxWidth: '400px', width: '100%' }}>
           <Flex direction="column" gap="2" align="center">
             <Flex justify="center" align="center" style={{ width: '100%' }}>
@@ -159,6 +178,25 @@ export const RegisterPage: React.FC = () => {
 
   return (
     <div className="auth-page">
+      <a
+        href="https://shinzo.ai"
+        style={{
+          position: 'absolute',
+          top: '20px',
+          left: '20px',
+          textDecoration: 'none'
+        }}
+      >
+        <img
+          src="/ShinzoIcon512.png"
+          alt="Back to Shinzo"
+          style={{
+            width: '48px',
+            height: '48px',
+            cursor: 'pointer'
+          }}
+        />
+      </a>
       <Card size="4" style={{ maxWidth: '400px', width: '100%' }}>
         <Flex direction="column" gap="2">
           <Flex justify="center" align="center" style={{ width: '100%' }}>


### PR DESCRIPTION
Added a Shinzo icon to the top-left corner of both the Login and Register pages (including the success state) that links back to https://shinzo.ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)