### PR TITLE
Add Live Support button to platform navbar

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -43,7 +43,7 @@ export const Header: React.FC = () => {
           <DropdownMenu.Trigger>
             <Button variant="outline" size="2">
               <Icons.ChatBubbleIcon />
-              Live Support
+              Need support?
               <Icons.ChevronDownIcon />
             </Button>
           </DropdownMenu.Trigger>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -38,6 +38,27 @@ export const Header: React.FC = () => {
           Docs
         </Button>
 
+        {/* Live Support dropdown */}
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger>
+            <Button variant="outline" size="2">
+              <Icons.ChatBubbleIcon />
+              Live Support
+              <Icons.ChevronDownIcon />
+            </Button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content align="end">
+            <DropdownMenu.Item onSelect={() => window.open('https://calendly.com/shinzolabs/meet-extended', '_blank')}>
+              <Icons.CalendarIcon />
+              Schedule a Meeting
+            </DropdownMenu.Item>
+            <DropdownMenu.Item onSelect={() => window.open('https://discord.gg/UYUdSdp5N8', '_blank')}>
+              <Icons.DiscordLogoIcon />
+              Join Discord
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Root>
+
         {/* User menu */}
         <DropdownMenu.Root>
         <DropdownMenu.Trigger>


### PR DESCRIPTION
Added dropdown menu with links to:
- Calendly meeting scheduler (https://calendly.com/shinzolabs/meet-extended)
- Discord community (https://discord.gg/UYUdSdp5N8)

Button positioned between Docs and user menu in header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)