### PR TITLE
Refactor auth pages to unified login/signup flow with OAuth options

### DIFF
--- a/backend/src/dbClient.ts
+++ b/backend/src/dbClient.ts
@@ -6,6 +6,7 @@ import {
   SubscriptionTier,
   UserPreferences,
   UserSurvey,
+  OAuthAccount,
   Resource,
   ResourceAttribute,
   IngestToken,
@@ -93,6 +94,7 @@ User.initialize(sequelize)
 SubscriptionTier.initialize(sequelize)
 UserPreferences.initialize(sequelize)
 UserSurvey.initialize(sequelize)
+OAuthAccount.initialize(sequelize)
 Resource.initialize(sequelize)
 ResourceAttribute.initialize(sequelize)
 IngestToken.initialize(sequelize)
@@ -121,6 +123,9 @@ User.hasMany(Resource, { foreignKey: 'user_uuid', as: 'resources' })
 User.hasMany(IngestToken, { foreignKey: 'user_uuid', as: 'ingestTokens' })
 User.belongsTo(SubscriptionTier, { foreignKey: 'subscription_tier_uuid', as: 'subscriptionTier' })
 User.hasMany(UserPreferences, { foreignKey: 'user_uuid', as: 'preferences' })
+User.hasMany(OAuthAccount, { foreignKey: 'user_uuid', as: 'oauthAccounts' })
+
+OAuthAccount.belongsTo(User, { foreignKey: 'user_uuid', as: 'user' })
 
 SubscriptionTier.hasMany(User, { foreignKey: 'subscription_tier_uuid', as: 'users' })
 

--- a/backend/src/handlers/oauthAccount.ts
+++ b/backend/src/handlers/oauthAccount.ts
@@ -1,0 +1,136 @@
+import { User, OAuthAccount } from '../models'
+import { logger } from '../logger'
+
+/**
+ * Get user's available authentication methods
+ * Returns which auth methods are available for this user (password, OAuth providers)
+ */
+export const handleGetAuthMethods = async (userUuid: string) => {
+  try {
+    const user = await User.findByPk(userUuid)
+    if (!user) {
+      return {
+        response: 'User not found',
+        error: true,
+        status: 404
+      }
+    }
+
+    // Check if user has password set
+    const hasPassword = !!(user.password_hash && user.password_salt)
+
+    // Get all linked OAuth providers
+    const oauthAccounts = await OAuthAccount.findAll({
+      where: { user_uuid: userUuid },
+      attributes: ['oauth_provider']
+    })
+
+    const oauthProviders = oauthAccounts.map(account => account.oauth_provider)
+
+    return {
+      response: {
+        hasPassword,
+        oauthProviders
+      },
+      status: 200
+    }
+  } catch (error: any) {
+    logger.error({ message: 'Error fetching auth methods', error, userUuid })
+    return {
+      response: 'Failed to fetch authentication methods',
+      error: true,
+      status: 500
+    }
+  }
+}
+
+/**
+ * Get all linked OAuth accounts for a user
+ */
+export const handleGetOAuthAccounts = async (userUuid: string) => {
+  try {
+    const oauthAccounts = await OAuthAccount.findAll({
+      where: { user_uuid: userUuid },
+      attributes: ['uuid', 'oauth_provider', 'oauth_email', 'linked_at', 'created_at'],
+      order: [['linked_at', 'DESC']]
+    })
+
+    return {
+      response: {
+        accounts: oauthAccounts
+      },
+      status: 200
+    }
+  } catch (error: any) {
+    logger.error({ message: 'Error fetching OAuth accounts', error, userUuid })
+    return {
+      response: 'Failed to fetch OAuth accounts',
+      error: true,
+      status: 500
+    }
+  }
+}
+
+/**
+ * Unlink an OAuth provider from a user's account
+ * Includes lockout prevention - won't allow unlinking if it's the only auth method
+ */
+export const handleUnlinkOAuthProvider = async (userUuid: string, provider: string) => {
+  try {
+    const user = await User.findByPk(userUuid)
+    if (!user) {
+      return {
+        response: 'User not found',
+        error: true,
+        status: 404
+      }
+    }
+
+    // Lockout prevention: Check if user has other auth methods
+    const hasPassword = !!(user.password_hash && user.password_salt)
+    const oauthAccountCount = await OAuthAccount.count({
+      where: { user_uuid: userUuid }
+    })
+
+    // If this is the only auth method, prevent unlinking
+    if (oauthAccountCount <= 1 && !hasPassword) {
+      return {
+        response: 'Cannot unlink your only authentication method. Please set a password or link another OAuth provider first.',
+        error: true,
+        status: 400
+      }
+    }
+
+    // Find and delete the OAuth account
+    const deleted = await OAuthAccount.destroy({
+      where: {
+        user_uuid: userUuid,
+        oauth_provider: provider
+      }
+    })
+
+    if (deleted === 0) {
+      return {
+        response: `${provider} account not found or already unlinked`,
+        error: true,
+        status: 404
+      }
+    }
+
+    logger.info({ message: 'OAuth provider unlinked', userUuid, provider })
+
+    return {
+      response: {
+        message: `${provider} account unlinked successfully`
+      },
+      status: 200
+    }
+  } catch (error: any) {
+    logger.error({ message: 'Error unlinking OAuth provider', error, userUuid, provider })
+    return {
+      response: 'Failed to unlink OAuth provider',
+      error: true,
+      status: 500
+    }
+  }
+}

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -2,6 +2,7 @@ import { User } from './main/User'
 import { SubscriptionTier } from './main/SubscriptionTier'
 import { UserPreferences } from './main/UserPreferences'
 import { UserSurvey } from './main/UserSurvey'
+import { OAuthAccount } from './main/OAuthAccount'
 import { Resource } from './open_telemetry/Resource'
 import { ResourceAttribute } from './open_telemetry/ResourceAttribute'
 import { IngestToken } from './open_telemetry/IngestToken'
@@ -28,6 +29,7 @@ export {
   SubscriptionTier,
   UserPreferences,
   UserSurvey,
+  OAuthAccount,
   Resource,
   ResourceAttribute,
   IngestToken,

--- a/backend/src/models/main/OAuthAccount.ts
+++ b/backend/src/models/main/OAuthAccount.ts
@@ -1,0 +1,57 @@
+import { DataTypes, Sequelize } from 'sequelize'
+import { CommonModel, commonFields } from '../Common'
+
+export class OAuthAccount extends CommonModel {
+  public user_uuid!: string
+  public oauth_provider!: 'google' | 'github'
+  public oauth_id!: string
+  public oauth_email!: string | null
+  public oauth_profile_data!: Record<string, any> | null
+  public linked_at!: Date
+
+  static initialize(sequelize: Sequelize) {
+    OAuthAccount.init(
+      {
+        ...commonFields,
+        user_uuid: {
+          type: DataTypes.UUID,
+          allowNull: false,
+        },
+        oauth_provider: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
+        oauth_id: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
+        oauth_email: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
+        oauth_profile_data: {
+          type: DataTypes.JSONB,
+          allowNull: true,
+        },
+        linked_at: {
+          type: DataTypes.DATE,
+          allowNull: false,
+          defaultValue: DataTypes.NOW,
+        },
+      },
+      {
+        sequelize,
+        modelName: 'OAuthAccount',
+        tableName: 'oauth_account',
+        schema: 'main',
+        timestamps: false,
+        indexes: [
+          {
+            unique: true,
+            fields: ['oauth_provider', 'oauth_id'],
+          },
+        ],
+      }
+    )
+  }
+}

--- a/backend/src/models/main/User.ts
+++ b/backend/src/models/main/User.ts
@@ -12,9 +12,6 @@ export class User extends CommonModel {
   public last_counter_reset!: Date
   public subscription_tier_uuid!: string
   public subscribed_on!: Date | null
-  public oauth_provider!: string | null
-  public oauth_id!: string | null
-  public oauth_profile_data!: Record<string, any> | null
 
   static initialize(sequelize: Sequelize) {
     User.init(
@@ -63,18 +60,6 @@ export class User extends CommonModel {
         },
         subscribed_on: {
           type: DataTypes.DATE,
-          allowNull: true,
-        },
-        oauth_provider: {
-          type: DataTypes.TEXT,
-          allowNull: true,
-        },
-        oauth_id: {
-          type: DataTypes.TEXT,
-          allowNull: true,
-        },
-        oauth_profile_data: {
-          type: DataTypes.JSONB,
           allowNull: true,
         },
       },

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -35,6 +35,12 @@ import {
 } from './handlers/oauth'
 
 import {
+  handleGetAuthMethods,
+  handleGetOAuthAccounts,
+  handleUnlinkOAuthProvider
+} from './handlers/oauthAccount'
+
+import {
   handleFetchResources,
   handleFetchTraces,
   handleFetchSpans,
@@ -368,6 +374,47 @@ app.post('/auth/oauth/github/callback', async (request: FastifyRequest, reply: F
     } else {
       reply.status(500).send({ error: 'Internal server error' })
     }
+  }
+})
+
+// OAuth account management endpoints
+app.get('/auth/methods', async (request: AuthenticatedRequest, reply: FastifyReply) => {
+  const authenticated = await authenticateJWT(request, reply)
+  if (!authenticated) return
+
+  try {
+    const result = await handleGetAuthMethods(request.user!.uuid)
+    reply.status(result.status || 200).send(result.response)
+  } catch (error: any) {
+    logger.error({ message: 'Get auth methods error', error })
+    reply.status(500).send({ error: 'Internal server error' })
+  }
+})
+
+app.get('/auth/oauth/accounts', async (request: AuthenticatedRequest, reply: FastifyReply) => {
+  const authenticated = await authenticateJWT(request, reply)
+  if (!authenticated) return
+
+  try {
+    const result = await handleGetOAuthAccounts(request.user!.uuid)
+    reply.status(result.status || 200).send(result.response)
+  } catch (error: any) {
+    logger.error({ message: 'Get OAuth accounts error', error })
+    reply.status(500).send({ error: 'Internal server error' })
+  }
+})
+
+app.delete('/auth/oauth/accounts/:provider', async (request: AuthenticatedRequest, reply: FastifyReply) => {
+  const authenticated = await authenticateJWT(request, reply)
+  if (!authenticated) return
+
+  try {
+    const { provider } = request.params as { provider: string }
+    const result = await handleUnlinkOAuthProvider(request.user!.uuid, provider)
+    reply.status(result.status || 200).send(result.response)
+  } catch (error: any) {
+    logger.error({ message: 'Unlink OAuth provider error', error })
+    reply.status(500).send({ error: 'Internal server error' })
   }
 })
 

--- a/db/migrations/20260204000000_add_oauth_account_support.sql
+++ b/db/migrations/20260204000000_add_oauth_account_support.sql
@@ -1,0 +1,71 @@
+-- migrate:up
+
+-- Step 1: Create oauth_account table to support multiple OAuth providers per user
+CREATE TABLE main.oauth_account (
+    uuid UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    user_uuid UUID NOT NULL REFERENCES main."user"(uuid) ON DELETE CASCADE,
+    oauth_provider TEXT NOT NULL,
+    oauth_id TEXT NOT NULL,
+    oauth_email TEXT,
+    oauth_profile_data JSONB,
+    linked_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(oauth_provider, oauth_id)
+);
+
+-- Create indexes for efficient lookups
+CREATE INDEX idx_oauth_account_user ON main.oauth_account(user_uuid);
+CREATE INDEX idx_oauth_account_provider_id ON main.oauth_account(oauth_provider, oauth_id);
+
+-- Step 2: Migrate existing OAuth data from user table to oauth_account table
+INSERT INTO main.oauth_account (user_uuid, oauth_provider, oauth_id, oauth_email, oauth_profile_data, linked_at)
+SELECT
+    uuid AS user_uuid,
+    oauth_provider,
+    oauth_id,
+    email AS oauth_email,
+    oauth_profile_data,
+    COALESCE(updated_at, created_at) AS linked_at
+FROM main."user"
+WHERE oauth_provider IS NOT NULL AND oauth_id IS NOT NULL;
+
+-- Step 3: Drop OAuth columns from user table (no longer needed)
+DROP INDEX IF EXISTS main.idx_user_oauth_provider_id;
+ALTER TABLE main."user" DROP COLUMN IF EXISTS oauth_provider;
+ALTER TABLE main."user" DROP COLUMN IF EXISTS oauth_id;
+ALTER TABLE main."user" DROP COLUMN IF EXISTS oauth_profile_data;
+
+-- migrate:down
+
+-- Restore OAuth columns to user table
+ALTER TABLE main."user"
+    ADD COLUMN oauth_provider TEXT,
+    ADD COLUMN oauth_id TEXT,
+    ADD COLUMN oauth_profile_data JSONB;
+
+-- Restore unique constraint
+CREATE UNIQUE INDEX idx_user_oauth_provider_id ON main."user"(oauth_provider, oauth_id)
+WHERE oauth_provider IS NOT NULL AND oauth_id IS NOT NULL;
+
+-- Migrate data back to user table (only the first OAuth account per user)
+UPDATE main."user" u
+SET
+    oauth_provider = oa.oauth_provider,
+    oauth_id = oa.oauth_id,
+    oauth_profile_data = oa.oauth_profile_data
+FROM (
+    SELECT DISTINCT ON (user_uuid)
+        user_uuid,
+        oauth_provider,
+        oauth_id,
+        oauth_profile_data
+    FROM main.oauth_account
+    ORDER BY user_uuid, linked_at ASC
+) oa
+WHERE u.uuid = oa.user_uuid;
+
+-- Drop indexes and table
+DROP INDEX IF EXISTS main.idx_oauth_account_provider_id;
+DROP INDEX IF EXISTS main.idx_oauth_account_user;
+DROP TABLE IF EXISTS main.oauth_account;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,6 +1,6 @@
-\restrict SLydAwJHmyNGe4zsmCJkjrIePyeopFw5LrRpxPbTzFp5uVZiiGIXJPTrMrwLppc
+\restrict cDZmRydbPYsa0iLq7nvZEhmdTFQH6l3vaDWoyIZPJMoHhSYq9n3m8HkzeUwDw5r
 
--- Dumped from database version 17.6
+-- Dumped from database version 15.14 (Homebrew)
 -- Dumped by pg_dump version 17.6
 
 SET statement_timeout = 0;
@@ -55,6 +55,23 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
+-- Name: oauth_account; Type: TABLE; Schema: main; Owner: -
+--
+
+CREATE TABLE main.oauth_account (
+    uuid uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    user_uuid uuid NOT NULL,
+    oauth_provider text NOT NULL,
+    oauth_id text NOT NULL,
+    oauth_email text,
+    oauth_profile_data jsonb,
+    linked_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
 -- Name: subscription_tier; Type: TABLE; Schema: main; Owner: -
 --
 
@@ -85,10 +102,7 @@ CREATE TABLE main."user" (
     monthly_counter integer DEFAULT 0 NOT NULL,
     last_counter_reset timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     subscription_tier_uuid uuid NOT NULL,
-    subscribed_on timestamp without time zone,
-    oauth_provider text,
-    oauth_id text,
-    oauth_profile_data jsonb
+    subscribed_on timestamp without time zone
 );
 
 
@@ -662,6 +676,22 @@ CREATE TABLE spotlight.user_analytics (
 
 
 --
+-- Name: oauth_account oauth_account_oauth_provider_oauth_id_key; Type: CONSTRAINT; Schema: main; Owner: -
+--
+
+ALTER TABLE ONLY main.oauth_account
+    ADD CONSTRAINT oauth_account_oauth_provider_oauth_id_key UNIQUE (oauth_provider, oauth_id);
+
+
+--
+-- Name: oauth_account oauth_account_pkey; Type: CONSTRAINT; Schema: main; Owner: -
+--
+
+ALTER TABLE ONLY main.oauth_account
+    ADD CONSTRAINT oauth_account_pkey PRIMARY KEY (uuid);
+
+
+--
 -- Name: subscription_tier subscription_tier_pkey; Type: CONSTRAINT; Schema: main; Owner: -
 --
 
@@ -998,17 +1028,24 @@ ALTER TABLE ONLY spotlight.user_analytics
 
 
 --
+-- Name: idx_oauth_account_provider_id; Type: INDEX; Schema: main; Owner: -
+--
+
+CREATE INDEX idx_oauth_account_provider_id ON main.oauth_account USING btree (oauth_provider, oauth_id);
+
+
+--
+-- Name: idx_oauth_account_user; Type: INDEX; Schema: main; Owner: -
+--
+
+CREATE INDEX idx_oauth_account_user ON main.oauth_account USING btree (user_uuid);
+
+
+--
 -- Name: idx_user_last_counter_reset; Type: INDEX; Schema: main; Owner: -
 --
 
 CREATE INDEX idx_user_last_counter_reset ON main."user" USING btree (last_counter_reset);
-
-
---
--- Name: idx_user_oauth_provider_id; Type: INDEX; Schema: main; Owner: -
---
-
-CREATE UNIQUE INDEX idx_user_oauth_provider_id ON main."user" USING btree (oauth_provider, oauth_id) WHERE ((oauth_provider IS NOT NULL) AND (oauth_id IS NOT NULL));
 
 
 --
@@ -1747,6 +1784,14 @@ CREATE TRIGGER updated_at_user_analytics BEFORE UPDATE ON spotlight.user_analyti
 
 
 --
+-- Name: oauth_account oauth_account_user_uuid_fkey; Type: FK CONSTRAINT; Schema: main; Owner: -
+--
+
+ALTER TABLE ONLY main.oauth_account
+    ADD CONSTRAINT oauth_account_user_uuid_fkey FOREIGN KEY (user_uuid) REFERENCES main."user"(uuid) ON DELETE CASCADE;
+
+
+--
 -- Name: user_preferences user_preferences_user_uuid_fkey; Type: FK CONSTRAINT; Schema: main; Owner: -
 --
 
@@ -2062,7 +2107,7 @@ ALTER TABLE ONLY spotlight.user_analytics
 -- PostgreSQL database dump complete
 --
 
-\unrestrict SLydAwJHmyNGe4zsmCJkjrIePyeopFw5LrRpxPbTzFp5uVZiiGIXJPTrMrwLppc
+\unrestrict cDZmRydbPYsa0iLq7nvZEhmdTFQH6l3vaDWoyIZPJMoHhSYq9n3m8HkzeUwDw5r
 
 
 --
@@ -2085,4 +2130,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20251218000000'),
     ('20251218100000'),
     ('20251218100001'),
-    ('20251218100002');
+    ('20251218100002'),
+    ('20260204000000');

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
                 "axios": "^1.7.7",
                 "clsx": "^2.1.1",
                 "date-fns": "^3.6.0",
+                "posthog-js": "^1.335.2",
                 "qrcode.react": "^4.2.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
@@ -70,7 +71,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -720,7 +720,6 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz",
             "integrity": "sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.27.1"
             },
@@ -1604,7 +1603,6 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
             "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.27.1",
                 "@babel/helper-module-imports": "^7.27.1",
@@ -2971,6 +2969,252 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@opentelemetry/api": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+            "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/api-logs": {
+            "version": "0.208.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+            "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/core": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+            "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+            "version": "0.208.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+            "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.208.0",
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/otlp-exporter-base": "0.208.0",
+                "@opentelemetry/otlp-transformer": "0.208.0",
+                "@opentelemetry/sdk-logs": "0.208.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.208.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+            "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/otlp-transformer": "0.208.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.208.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+            "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.208.0",
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/resources": "2.2.0",
+                "@opentelemetry/sdk-logs": "0.208.0",
+                "@opentelemetry/sdk-metrics": "2.2.0",
+                "@opentelemetry/sdk-trace-base": "2.2.0",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+            "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/resources": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
+            "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.5.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
+            "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.208.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+            "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.208.0",
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/resources": "2.2.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+            "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-metrics": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+            "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/resources": "2.2.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+            "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+            "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/resources": "2.2.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+            "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.39.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
+            "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
             "version": "0.5.17",
             "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.17.tgz",
@@ -3018,6 +3262,85 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/@posthog/core": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.17.0.tgz",
+            "integrity": "sha512-8pDNL+/u9ojzXloA5wILVDXBCV5daJ7w2ipCALQlEEZmL752cCKhRpbyiHn3tjKXh3Hy6aOboJneYa1JdlVHrQ==",
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.6"
+            }
+        },
+        "node_modules/@posthog/types": {
+            "version": "1.336.4",
+            "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.336.4.tgz",
+            "integrity": "sha512-BY3cq/8segbXEvHbEXx9SWmaKJEM0AGgsOgMFH2yy13AV+rUHsGcp4Z5LDI5pU25DURN9EAZvzcoVyYy/Iokmw==",
+            "license": "MIT"
+        },
+        "node_modules/@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "node_modules/@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@radix-ui/colors": {
             "version": "3.0.0",
@@ -5270,7 +5593,6 @@
             "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -5282,7 +5604,6 @@
             "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^18.0.0"
             }
@@ -5397,7 +5718,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
             "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.4.0",
                 "@typescript-eslint/scope-manager": "5.62.0",
@@ -5451,7 +5771,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
             "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -5821,7 +6140,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5920,7 +6238,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -6878,7 +7195,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -8458,6 +8774,15 @@
                 "url": "https://github.com/fb55/domhandler?sponsor=1"
             }
         },
+        "node_modules/dompurify": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+            "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
+            }
+        },
         "node_modules/domutils": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
@@ -8865,7 +9190,6 @@
             "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -9691,6 +10015,12 @@
             "dependencies": {
                 "bser": "2.1.1"
             }
+        },
+        "node_modules/fflate": {
+            "version": "0.4.8",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+            "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+            "license": "MIT"
         },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
@@ -11621,7 +11951,6 @@
             "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
             "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "^27.5.1",
                 "import-local": "^3.0.2",
@@ -12519,7 +12848,6 @@
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -12899,6 +13227,12 @@
             "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
             "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
             "license": "MIT"
+        },
+        "node_modules/long": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+            "license": "Apache-2.0"
         },
         "node_modules/loose-envify": {
             "version": "1.4.0",
@@ -13892,7 +14226,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -15027,7 +15360,6 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
             "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -15131,6 +15463,37 @@
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "license": "MIT"
         },
+        "node_modules/posthog-js": {
+            "version": "1.336.4",
+            "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.336.4.tgz",
+            "integrity": "sha512-NX81XaqOjS/gue3UsbAAuJxi6vD0AGy1HUvywBIhAArCwbTXKS04NhEFwUcYJdrmwXUf94MntEIWGoc1pTFDtg==",
+            "license": "SEE LICENSE IN LICENSE",
+            "dependencies": {
+                "@opentelemetry/api": "^1.9.0",
+                "@opentelemetry/api-logs": "^0.208.0",
+                "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+                "@opentelemetry/resources": "^2.2.0",
+                "@opentelemetry/sdk-logs": "^0.208.0",
+                "@posthog/core": "1.17.0",
+                "@posthog/types": "1.336.4",
+                "core-js": "^3.38.1",
+                "dompurify": "^3.3.1",
+                "fflate": "^0.4.8",
+                "preact": "^10.28.2",
+                "query-selector-shadow-dom": "^1.0.1",
+                "web-vitals": "^5.1.0"
+            }
+        },
+        "node_modules/preact": {
+            "version": "10.28.3",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz",
+            "integrity": "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/preact"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -15233,6 +15596,30 @@
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "license": "MIT"
         },
+        "node_modules/protobufjs": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+            "hasInstallScript": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/node": ">=13.7.0",
+                "long": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -15316,6 +15703,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/query-selector-shadow-dom": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+            "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+            "license": "MIT"
         },
         "node_modules/querystringify": {
             "version": "2.2.0",
@@ -15479,7 +15872,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -15614,7 +16006,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -15675,7 +16066,6 @@
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
             "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -16285,7 +16675,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
             "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -16531,7 +16920,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -18006,7 +18394,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -18283,7 +18670,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -18668,6 +19054,12 @@
                 "minimalistic-assert": "^1.0.0"
             }
         },
+        "node_modules/web-vitals": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+            "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+            "license": "Apache-2.0"
+        },
         "node_modules/webidl-conversions": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -18682,7 +19074,6 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
             "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -19166,7 +19557,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -104,7 +104,7 @@ html {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #0f0f23 0%, #1a1a3e 25%, #2d1b4e 50%, #1e3a5f 75%, #0f2027 100%);
+  background: linear-gradient(90deg, rgb(194, 229, 255) 0%, rgb(153, 255, 248) 50%, rgb(92, 122, 255) 100%);
 }
 
 /* Two-column auth layout */
@@ -112,21 +112,75 @@ html {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 60px;
+  gap: 80px;
   width: 100%;
-  max-width: 1200px;
+  max-width: 1400px;
   padding: 40px;
 }
 
 /* Feature checklist panel (left side) */
 .feature-checklist-panel {
-  flex: 1;
-  max-width: 520px;
+  flex-shrink: 0;
+}
+
+.feature-card {
+  width: 580px;
+  padding: 24px;
+  background-color: rgb(130, 160, 255);
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
 /* Auth form container (right side) */
 .auth-form-container {
   flex-shrink: 0;
+}
+
+/* Auth page hyperlinks */
+.auth-link {
+  color: #1a56db;
+  text-decoration: underline;
+  transition: color 0.15s ease;
+}
+
+.auth-link:hover {
+  color: #1e40af;
+}
+
+.auth-link:active {
+  color: #7c3aed;
+}
+
+/* Feature panel items */
+.feature-item {
+  padding: 12px;
+  background-color: white;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  transition: all 0.2s ease;
+  cursor: default;
+}
+
+.feature-item:hover {
+  background-color: #f8fafc;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.feature-item:hover .feature-icon {
+  transform: scale(1.05);
+}
+
+.feature-icon {
+  transition: all 0.2s ease;
+}
+
+.feature-item .rt-Text {
+  color: #1e293b;
+}
+
+.feature-item .rt-Text[data-accent-color="gray"] {
+  color: #64748b;
 }
 
 /* Hide feature panel on mobile/tablet, show only on larger screens */

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -104,7 +104,54 @@ html {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(90deg, rgb(194, 229, 255) 0%, rgb(153, 255, 248) 50%, rgb(92, 122, 255) 100%);
+  background: linear-gradient(135deg, #0f0f23 0%, #1a1a3e 25%, #2d1b4e 50%, #1e3a5f 75%, #0f2027 100%);
+}
+
+/* Two-column auth layout */
+.auth-layout {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 60px;
+  width: 100%;
+  max-width: 1200px;
+  padding: 40px;
+}
+
+/* Feature checklist panel (left side) */
+.feature-checklist-panel {
+  flex: 1;
+  max-width: 520px;
+}
+
+/* Auth form container (right side) */
+.auth-form-container {
+  flex-shrink: 0;
+}
+
+/* Hide feature panel on mobile/tablet, show only on larger screens */
+@media (max-width: 1024px) {
+  .auth-layout {
+    gap: 40px;
+    padding: 20px;
+  }
+
+  .feature-checklist-panel {
+    display: none;
+  }
+
+  .auth-form-container {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+  }
+}
+
+/* Adjust feature grid to single column on medium screens */
+@media (max-width: 1200px) and (min-width: 1025px) {
+  .feature-checklist-panel {
+    max-width: 400px;
+  }
 }
 
 /* Loading states */

--- a/frontend/src/backendService.ts
+++ b/frontend/src/backendService.ts
@@ -205,6 +205,43 @@ export const authService = {
   }
 }
 
+interface OAuthAccount {
+  uuid: string
+  oauth_provider: 'google' | 'github'
+  oauth_email: string | null
+  linked_at: string
+  created_at: string
+}
+
+interface AuthMethods {
+  hasPassword: boolean
+  oauthProviders: string[]
+}
+
+export const oauthAccountService = {
+  async fetchAuthMethods(token: string): Promise<AuthMethods> {
+    const response = await fetch(`${API_BASE_URL}/auth/methods`, {
+      headers: getAuthHeaders(token)
+    })
+    return handleResponse(response)
+  },
+
+  async fetchOAuthAccounts(token: string): Promise<{ accounts: OAuthAccount[] }> {
+    const response = await fetch(`${API_BASE_URL}/auth/oauth/accounts`, {
+      headers: getAuthHeaders(token)
+    })
+    return handleResponse(response)
+  },
+
+  async unlinkOAuthProvider(token: string, provider: string): Promise<{ message: string }> {
+    const response = await fetch(`${API_BASE_URL}/auth/oauth/accounts/${provider}`, {
+      method: 'DELETE',
+      headers: getAuthHeaders(token)
+    })
+    return handleResponse(response)
+  }
+}
+
 export const ingestTokenService = {
   async generate(token: string): Promise<{ token: string; uuid: string; status: string; created_at: string }> {
     const response = await fetch(`${API_BASE_URL}/auth/generate_ingest_token`, {

--- a/frontend/src/components/auth/FeatureChecklist.tsx
+++ b/frontend/src/components/auth/FeatureChecklist.tsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import { Flex, Text, Heading, Box } from '@radix-ui/themes'
+import {
+  ActivityLogIcon,
+  BarChartIcon,
+  GlobeIcon,
+  LightningBoltIcon,
+  MixerHorizontalIcon,
+  RocketIcon
+} from '@radix-ui/react-icons'
+
+interface FeatureItem {
+  icon: React.ReactNode
+  title: string
+}
+
+const features: FeatureItem[] = [
+  {
+    icon: <ActivityLogIcon width="20" height="20" />,
+    title: 'Real-time trace analysis for AI agent sessions'
+  },
+  {
+    icon: <BarChartIcon width="20" height="20" />,
+    title: 'Token usage analytics and cost tracking'
+  },
+  {
+    icon: <LightningBoltIcon width="20" height="20" />,
+    title: 'Identify performance bottlenecks instantly'
+  },
+  {
+    icon: <MixerHorizontalIcon width="20" height="20" />,
+    title: 'MCP server monitoring and tool usage stats'
+  },
+  {
+    icon: <GlobeIcon width="20" height="20" />,
+    title: 'OpenTelemetry compliant, industry standard'
+  },
+  {
+    icon: <RocketIcon width="20" height="20" />,
+    title: 'Self-hostable with enterprise-grade security'
+  }
+]
+
+export const FeatureChecklist: React.FC = () => {
+  return (
+    <Box className="feature-checklist-panel">
+      <Flex direction="column" gap="6" style={{ maxWidth: '480px' }}>
+        <Flex direction="column" gap="3">
+          <Heading size="7" style={{ color: 'white', fontWeight: 600 }}>
+            AI Agent Observability Platform
+          </Heading>
+          <Text size="3" style={{ color: 'rgba(255, 255, 255, 0.8)' }}>
+            From development to production, gain complete visibility into your AI agents and MCP servers
+          </Text>
+        </Flex>
+
+        <Box
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(2, 1fr)',
+            gap: '20px'
+          }}
+        >
+          {features.map((feature, index) => (
+            <Flex
+              key={index}
+              align="start"
+              gap="3"
+              style={{
+                padding: '16px',
+                backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                borderRadius: '12px',
+                backdropFilter: 'blur(10px)',
+                border: '1px solid rgba(255, 255, 255, 0.15)'
+              }}
+            >
+              <Flex
+                align="center"
+                justify="center"
+                style={{
+                  width: '40px',
+                  height: '40px',
+                  backgroundColor: 'rgba(255, 255, 255, 0.15)',
+                  borderRadius: '10px',
+                  color: 'white',
+                  flexShrink: 0
+                }}
+              >
+                {feature.icon}
+              </Flex>
+              <Text size="2" style={{ color: 'white', lineHeight: 1.5 }}>
+                {feature.title}
+              </Text>
+            </Flex>
+          ))}
+        </Box>
+      </Flex>
+    </Box>
+  )
+}

--- a/frontend/src/components/auth/FeatureChecklist.tsx
+++ b/frontend/src/components/auth/FeatureChecklist.tsx
@@ -12,89 +12,95 @@ import {
 interface FeatureItem {
   icon: React.ReactNode
   title: string
+  description: string
 }
 
 const features: FeatureItem[] = [
   {
-    icon: <ActivityLogIcon width="20" height="20" />,
-    title: 'Real-time trace analysis for AI agent sessions'
+    icon: <ActivityLogIcon width="24" height="24" />,
+    title: 'Real-time Trace Analysis',
+    description: 'Monitor AI agent sessions with detailed execution traces and conversation flows'
   },
   {
-    icon: <BarChartIcon width="20" height="20" />,
-    title: 'Token usage analytics and cost tracking'
+    icon: <BarChartIcon width="24" height="24" />,
+    title: 'Token Usage & Cost Tracking',
+    description: 'Track token consumption and costs across all your AI models and providers'
   },
   {
-    icon: <LightningBoltIcon width="20" height="20" />,
-    title: 'Identify performance bottlenecks instantly'
+    icon: <LightningBoltIcon width="24" height="24" />,
+    title: 'Performance Insights',
+    description: 'Identify bottlenecks and optimize response times with actionable metrics'
   },
   {
-    icon: <MixerHorizontalIcon width="20" height="20" />,
-    title: 'MCP server monitoring and tool usage stats'
+    icon: <MixerHorizontalIcon width="24" height="24" />,
+    title: 'MCP Server Monitoring',
+    description: 'Monitor tool usage, success rates, and performance across MCP servers'
   },
   {
-    icon: <GlobeIcon width="20" height="20" />,
-    title: 'OpenTelemetry compliant, industry standard'
+    icon: <GlobeIcon width="24" height="24" />,
+    title: 'OpenTelemetry Native',
+    description: 'Industry-standard instrumentation that integrates with your existing stack'
   },
   {
-    icon: <RocketIcon width="20" height="20" />,
-    title: 'Self-hostable with enterprise-grade security'
+    icon: <RocketIcon width="24" height="24" />,
+    title: 'Self-Hostable',
+    description: 'Deploy on your infrastructure with enterprise-grade security and compliance'
   }
 ]
 
 export const FeatureChecklist: React.FC = () => {
   return (
     <Box className="feature-checklist-panel">
-      <Flex direction="column" gap="6" style={{ maxWidth: '480px' }}>
-        <Flex direction="column" gap="3">
-          <Heading size="7" style={{ color: 'white', fontWeight: 600 }}>
-            AI Agent Observability Platform
-          </Heading>
-          <Text size="3" style={{ color: 'rgba(255, 255, 255, 0.8)' }}>
-            From development to production, gain complete visibility into your AI agents and MCP servers
-          </Text>
-        </Flex>
+      <div className="feature-card">
+        <Flex direction="column" gap="5">
+          <Flex direction="column" gap="2">
+            <Heading size="8" style={{ fontWeight: 600, color: 'white' }}>
+              AI Agent Observability Platform
+            </Heading>
+            <Text size="4" style={{ color: 'rgba(255, 255, 255, 0.85)' }}>
+              From development to production, gain complete visibility into your AI agents and MCP servers
+            </Text>
+          </Flex>
 
-        <Box
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(2, 1fr)',
-            gap: '20px'
-          }}
-        >
-          {features.map((feature, index) => (
-            <Flex
-              key={index}
-              align="start"
-              gap="3"
-              style={{
-                padding: '16px',
-                backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                borderRadius: '12px',
-                backdropFilter: 'blur(10px)',
-                border: '1px solid rgba(255, 255, 255, 0.15)'
-              }}
-            >
-              <Flex
-                align="center"
-                justify="center"
-                style={{
-                  width: '40px',
-                  height: '40px',
-                  backgroundColor: 'rgba(255, 255, 255, 0.15)',
-                  borderRadius: '10px',
-                  color: 'white',
-                  flexShrink: 0
-                }}
-              >
-                {feature.icon}
-              </Flex>
-              <Text size="2" style={{ color: 'white', lineHeight: 1.5 }}>
-                {feature.title}
-              </Text>
-            </Flex>
-          ))}
-        </Box>
-      </Flex>
+          <Box
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(2, 1fr)',
+              gap: '12px'
+            }}
+          >
+            {features.map((feature, index) => (
+              <Box key={index} className="feature-item">
+                <Flex align="center" gap="3">
+                  <Flex
+                    align="center"
+                    justify="center"
+                    className="feature-icon"
+                    style={{
+                      width: '36px',
+                      height: '36px',
+                      backgroundColor: 'var(--accent-3)',
+                      borderRadius: '8px',
+                      color: 'var(--accent-11)',
+                      flexShrink: 0
+                    }}
+                  >
+                    {feature.icon}
+                  </Flex>
+                  <Flex direction="column" gap="1">
+                    <Text size="2" weight="medium">
+                      {feature.title}
+                    </Text>
+                    <Text size="1" color="gray">
+                      {feature.description}
+                    </Text>
+                  </Flex>
+                </Flex>
+              </Box>
+            ))}
+          </Box>
+        </Flex>
+      </div>
     </Box>
   )
 }

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../../contexts/AuthContext'
-import { Button, TextField, Checkbox, Text, Heading, Card, Flex, Callout, Separator } from '@radix-ui/themes'
+import { Button, TextField, Text, Heading, Card, Flex, Callout, Separator } from '@radix-ui/themes'
 import { EyeOpenIcon, EyeNoneIcon, ExclamationTriangleIcon } from '@radix-ui/react-icons'
 import { FeatureChecklist } from '../../components/auth/FeatureChecklist'
 
@@ -9,7 +9,6 @@ export const LoginPage: React.FC = () => {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [showPassword, setShowPassword] = useState(false)
-  const [rememberMe, setRememberMe] = useState(false)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -24,7 +23,7 @@ export const LoginPage: React.FC = () => {
     setLoading(true)
 
     try {
-      await login(email, password, rememberMe)
+      await login(email, password)
       navigate(returnTo)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed')
@@ -93,7 +92,7 @@ export const LoginPage: React.FC = () => {
       <div className="auth-layout">
         <FeatureChecklist />
         <div className="auth-form-container">
-          <Card size="4" style={{ maxWidth: '400px', width: '100%' }}>
+          <Card size="4" style={{ width: '480px' }}>
         <Flex direction="column" gap="2">
           <Flex justify="center" align="center" style={{ width: '100%' }}>
             <a
@@ -116,33 +115,34 @@ export const LoginPage: React.FC = () => {
           </Flex>
 
           <Flex direction="column" gap="2" align="center">
-            <Heading size="6">Welcome to Shinzo</Heading>
-            <Text size="2" color="gray">
-              Sign in to your account to continue
-            </Text>
+            <Heading size="8">Welcome to Shinzo</Heading>
           </Flex>
+
+          <div style={{ height: '24px' }} />
 
           <form onSubmit={handleSubmit}>
             <Flex direction="column" gap="4">
-              <Flex direction="column" gap="2">
-                <Text size="2" weight="medium">Email</Text>
+              <Flex align="center" gap="3">
+                <Text size="2" weight="medium" style={{ width: '80px', flexShrink: 0 }}>Email</Text>
                 <TextField.Root
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="Enter your email"
                   required
+                  style={{ flex: 1 }}
                 />
               </Flex>
 
-              <Flex direction="column" gap="2">
-                <Text size="2" weight="medium">Password</Text>
+              <Flex align="center" gap="3">
+                <Text size="2" weight="medium" style={{ width: '80px', flexShrink: 0 }}>Password</Text>
                 <TextField.Root
                   type={showPassword ? 'text' : 'password'}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   placeholder="Enter your password"
                   required
+                  style={{ flex: 1 }}
                 >
                   <TextField.Slot side="right">
                     <Button
@@ -155,17 +155,6 @@ export const LoginPage: React.FC = () => {
                     </Button>
                   </TextField.Slot>
                 </TextField.Root>
-              </Flex>
-
-              <Flex align="center" gap="2">
-                <Checkbox
-                  id="remember-me"
-                  checked={rememberMe}
-                  onCheckedChange={(checked) => setRememberMe(checked === true)}
-                />
-                <Text size="2" color="gray">
-                  Remember me
-                </Text>
               </Flex>
 
               {error && (
@@ -202,7 +191,7 @@ export const LoginPage: React.FC = () => {
 
               <Text size="2" color="gray" align="center">
                 Don't have an account?{' '}
-                <Link to={`/register${returnTo !== '/dashboard' ? `?returnTo=${encodeURIComponent(returnTo)}` : ''}`} style={{ color: 'var(--accent-9)', textDecoration: 'none' }}>
+                <Link to={`/register${returnTo !== '/dashboard' ? `?returnTo=${encodeURIComponent(returnTo)}` : ''}`} className="auth-link">
                   Create one
                 </Link>
               </Text>
@@ -213,50 +202,49 @@ export const LoginPage: React.FC = () => {
                 <Separator size="4" style={{ flex: 1 }} />
               </Flex>
 
-              <Button
-                type="button"
-                size="3"
-                variant="outline"
-                style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '8px' }}
-                onClick={handleGoogleLogin}
-                disabled={loading}
-              >
-                <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17.64 9.20454C17.64 8.56636 17.5827 7.95272 17.4764 7.36363H9V10.845H13.8436C13.635 11.97 13.0009 12.9232 12.0477 13.5614V15.8195H14.9564C16.6582 14.2527 17.64 11.9454 17.64 9.20454Z" fill="#4285F4"/>
-                  <path d="M9 18C11.43 18 13.4673 17.1941 14.9564 15.8195L12.0477 13.5614C11.2418 14.1014 10.2109 14.4204 9 14.4204C6.65591 14.4204 4.67182 12.8373 3.96409 10.71H0.957275V13.0418C2.43818 15.9832 5.48182 18 9 18Z" fill="#34A853"/>
-                  <path d="M3.96409 10.71C3.78409 10.17 3.68182 9.59318 3.68182 9C3.68182 8.40682 3.78409 7.83 3.96409 7.29V4.95818H0.957275C0.347727 6.17318 0 7.54773 0 9C0 10.4523 0.347727 11.8268 0.957275 13.0418L3.96409 10.71Z" fill="#FBBC05"/>
-                  <path d="M9 3.57955C10.3214 3.57955 11.5077 4.03364 12.4405 4.92545L15.0218 2.34409C13.4632 0.891818 11.4259 0 9 0C5.48182 0 2.43818 2.01682 0.957275 4.95818L3.96409 7.29C4.67182 5.16273 6.65591 3.57955 9 3.57955Z" fill="#EA4335"/>
-                </svg>
-                Continue with Google
-              </Button>
+              <Flex gap="3">
+                <Button
+                  type="button"
+                  size="3"
+                  variant="outline"
+                  style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                  onClick={handleGoogleLogin}
+                  disabled={loading}
+                >
+                  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M17.64 9.20454C17.64 8.56636 17.5827 7.95272 17.4764 7.36363H9V10.845H13.8436C13.635 11.97 13.0009 12.9232 12.0477 13.5614V15.8195H14.9564C16.6582 14.2527 17.64 11.9454 17.64 9.20454Z" fill="#4285F4"/>
+                    <path d="M9 18C11.43 18 13.4673 17.1941 14.9564 15.8195L12.0477 13.5614C11.2418 14.1014 10.2109 14.4204 9 14.4204C6.65591 14.4204 4.67182 12.8373 3.96409 10.71H0.957275V13.0418C2.43818 15.9832 5.48182 18 9 18Z" fill="#34A853"/>
+                    <path d="M3.96409 10.71C3.78409 10.17 3.68182 9.59318 3.68182 9C3.68182 8.40682 3.78409 7.83 3.96409 7.29V4.95818H0.957275C0.347727 6.17318 0 7.54773 0 9C0 10.4523 0.347727 11.8268 0.957275 13.0418L3.96409 10.71Z" fill="#FBBC05"/>
+                    <path d="M9 3.57955C10.3214 3.57955 11.5077 4.03364 12.4405 4.92545L15.0218 2.34409C13.4632 0.891818 11.4259 0 9 0C5.48182 0 2.43818 2.01682 0.957275 4.95818L3.96409 7.29C4.67182 5.16273 6.65591 3.57955 9 3.57955Z" fill="#EA4335"/>
+                  </svg>
+                </Button>
 
-              <Button
-                type="button"
-                size="3"
-                variant="outline"
-                style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '8px' }}
-                onClick={handleGithubLogin}
-                disabled={loading}
-              >
-                <svg width="18" height="18" viewBox="0 0 98 96" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                  <path fillRule="evenodd" clipRule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"/>
-                </svg>
-                Continue with GitHub
-              </Button>
+                <Button
+                  type="button"
+                  size="3"
+                  variant="outline"
+                  style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                  onClick={handleGithubLogin}
+                  disabled={loading}
+                >
+                  <svg width="18" height="18" viewBox="0 0 98 96" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                    <path fillRule="evenodd" clipRule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"/>
+                  </svg>
+                </Button>
+              </Flex>
             </Flex>
           </form>
 
-          <Flex direction="column" gap="4" align="center">
-            <Flex gap="2" align="center">
-              <a href="https://www.shinzo.ai/privacy" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--gray-9)', textDecoration: 'none', fontSize: '12px' }}>
-                Privacy Policy
-              </a>
-              <Text size="1" color="gray">•</Text>
-              <a href="https://www.shinzo.ai/terms" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--gray-9)', textDecoration: 'none', fontSize: '12px' }}>
-                Terms of Service
-              </a>
-            </Flex>
+          <Flex justify="center" gap="2" style={{ marginTop: '16px' }}>
+            <a href="https://www.shinzo.ai/terms" target="_blank" rel="noopener noreferrer" className="auth-link" style={{ fontSize: '12px' }}>
+              Terms of Service
+            </a>
+            <Text size="1" color="gray">•</Text>
+            <a href="https://www.shinzo.ai/privacy" target="_blank" rel="noopener noreferrer" className="auth-link" style={{ fontSize: '12px' }}>
+              Privacy Policy
+            </a>
           </Flex>
+
         </Flex>
       </Card>
         </div>

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../../contexts/AuthContext'
 import { Button, TextField, Checkbox, Text, Heading, Card, Flex, Callout, Separator } from '@radix-ui/themes'
 import { EyeOpenIcon, EyeNoneIcon, ExclamationTriangleIcon } from '@radix-ui/react-icons'
+import { FeatureChecklist } from '../../components/auth/FeatureChecklist'
 
 export const LoginPage: React.FC = () => {
   const [email, setEmail] = useState('')
@@ -89,7 +90,10 @@ export const LoginPage: React.FC = () => {
           }}
         />
       </a>
-      <Card size="4" style={{ maxWidth: '400px', width: '100%' }}>
+      <div className="auth-layout">
+        <FeatureChecklist />
+        <div className="auth-form-container">
+          <Card size="4" style={{ maxWidth: '400px', width: '100%' }}>
         <Flex direction="column" gap="2">
           <Flex justify="center" align="center" style={{ width: '100%' }}>
             <a
@@ -255,6 +259,8 @@ export const LoginPage: React.FC = () => {
           </Flex>
         </Flex>
       </Card>
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -11,7 +11,6 @@ export const LoginPage: React.FC = () => {
   const [rememberMe, setRememberMe] = useState(false)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
-  const [loginMode, setLoginMode] = useState<'oauth' | 'email'>('oauth')
 
   const { login, loginWithGoogle, loginWithGithub } = useAuth()
   const navigate = useNavigate()
@@ -119,63 +118,7 @@ export const LoginPage: React.FC = () => {
             </Text>
           </Flex>
 
-          {loginMode === 'oauth' ? (
-            <Flex direction="column" gap="4">
-              <Button
-                type="button"
-                size="3"
-                variant="outline"
-                style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '8px' }}
-                onClick={handleGoogleLogin}
-                disabled={loading}
-              >
-                <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17.64 9.20454C17.64 8.56636 17.5827 7.95272 17.4764 7.36363H9V10.845H13.8436C13.635 11.97 13.0009 12.9232 12.0477 13.5614V15.8195H14.9564C16.6582 14.2527 17.64 11.9454 17.64 9.20454Z" fill="#4285F4"/>
-                  <path d="M9 18C11.43 18 13.4673 17.1941 14.9564 15.8195L12.0477 13.5614C11.2418 14.1014 10.2109 14.4204 9 14.4204C6.65591 14.4204 4.67182 12.8373 3.96409 10.71H0.957275V13.0418C2.43818 15.9832 5.48182 18 9 18Z" fill="#34A853"/>
-                  <path d="M3.96409 10.71C3.78409 10.17 3.68182 9.59318 3.68182 9C3.68182 8.40682 3.78409 7.83 3.96409 7.29V4.95818H0.957275C0.347727 6.17318 0 7.54773 0 9C0 10.4523 0.347727 11.8268 0.957275 13.0418L3.96409 10.71Z" fill="#FBBC05"/>
-                  <path d="M9 3.57955C10.3214 3.57955 11.5077 4.03364 12.4405 4.92545L15.0218 2.34409C13.4632 0.891818 11.4259 0 9 0C5.48182 0 2.43818 2.01682 0.957275 4.95818L3.96409 7.29C4.67182 5.16273 6.65591 3.57955 9 3.57955Z" fill="#EA4335"/>
-                </svg>
-                Continue with Google
-              </Button>
-
-              <Button
-                type="button"
-                size="3"
-                variant="outline"
-                style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '8px' }}
-                onClick={handleGithubLogin}
-                disabled={loading}
-              >
-                <svg width="18" height="18" viewBox="0 0 98 96" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                  <path fillRule="evenodd" clipRule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"/>
-                </svg>
-                Continue with GitHub
-              </Button>
-
-              {error && (
-                <Callout.Root color="red">
-                  <Callout.Icon>
-                    <ExclamationTriangleIcon />
-                  </Callout.Icon>
-                  <Callout.Text>{error}</Callout.Text>
-                </Callout.Root>
-              )}
-
-              <Flex direction="column" gap="3" align="center" style={{ marginTop: '8px' }}>
-                <Separator size="4" />
-                <Text size="2" color="gray">
-                  Looking for legacy login?{' '}
-                  <span
-                    onClick={() => setLoginMode('email')}
-                    style={{ color: 'var(--accent-9)', cursor: 'pointer', textDecoration: 'underline' }}
-                  >
-                    Login here
-                  </span>
-                </Text>
-              </Flex>
-            </Flex>
-          ) : (
-            <form onSubmit={handleSubmit}>
+          <form onSubmit={handleSubmit}>
             <Flex direction="column" gap="4">
               <Flex direction="column" gap="2">
                 <Text size="2" weight="medium">Email</Text>
@@ -253,21 +196,51 @@ export const LoginPage: React.FC = () => {
                 {loading ? 'Signing in...' : 'Sign in'}
               </Button>
 
-              <Flex direction="column" gap="3" align="center" style={{ marginTop: '8px' }}>
-                <Separator size="4" />
-                <Text size="2" color="gray">
-                  If you don't have a legacy account,{' '}
-                  <span
-                    onClick={() => setLoginMode('oauth')}
-                    style={{ color: 'var(--accent-9)', cursor: 'pointer', textDecoration: 'underline' }}
-                  >
-                    login here
-                  </span>
-                </Text>
+              <Text size="2" color="gray" align="center">
+                Don't have an account?{' '}
+                <Link to={`/register${returnTo !== '/dashboard' ? `?returnTo=${encodeURIComponent(returnTo)}` : ''}`} style={{ color: 'var(--accent-9)', textDecoration: 'none' }}>
+                  Create one
+                </Link>
+              </Text>
+
+              <Flex align="center" gap="3" style={{ marginTop: '4px' }}>
+                <Separator size="4" style={{ flex: 1 }} />
+                <Text size="2" color="gray">or</Text>
+                <Separator size="4" style={{ flex: 1 }} />
               </Flex>
+
+              <Button
+                type="button"
+                size="3"
+                variant="outline"
+                style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '8px' }}
+                onClick={handleGoogleLogin}
+                disabled={loading}
+              >
+                <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M17.64 9.20454C17.64 8.56636 17.5827 7.95272 17.4764 7.36363H9V10.845H13.8436C13.635 11.97 13.0009 12.9232 12.0477 13.5614V15.8195H14.9564C16.6582 14.2527 17.64 11.9454 17.64 9.20454Z" fill="#4285F4"/>
+                  <path d="M9 18C11.43 18 13.4673 17.1941 14.9564 15.8195L12.0477 13.5614C11.2418 14.1014 10.2109 14.4204 9 14.4204C6.65591 14.4204 4.67182 12.8373 3.96409 10.71H0.957275V13.0418C2.43818 15.9832 5.48182 18 9 18Z" fill="#34A853"/>
+                  <path d="M3.96409 10.71C3.78409 10.17 3.68182 9.59318 3.68182 9C3.68182 8.40682 3.78409 7.83 3.96409 7.29V4.95818H0.957275C0.347727 6.17318 0 7.54773 0 9C0 10.4523 0.347727 11.8268 0.957275 13.0418L3.96409 10.71Z" fill="#FBBC05"/>
+                  <path d="M9 3.57955C10.3214 3.57955 11.5077 4.03364 12.4405 4.92545L15.0218 2.34409C13.4632 0.891818 11.4259 0 9 0C5.48182 0 2.43818 2.01682 0.957275 4.95818L3.96409 7.29C4.67182 5.16273 6.65591 3.57955 9 3.57955Z" fill="#EA4335"/>
+                </svg>
+                Continue with Google
+              </Button>
+
+              <Button
+                type="button"
+                size="3"
+                variant="outline"
+                style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '8px' }}
+                onClick={handleGithubLogin}
+                disabled={loading}
+              >
+                <svg width="18" height="18" viewBox="0 0 98 96" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                  <path fillRule="evenodd" clipRule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"/>
+                </svg>
+                Continue with GitHub
+              </Button>
             </Flex>
           </form>
-          )}
 
           <Flex direction="column" gap="4" align="center">
             <Flex gap="2" align="center">

--- a/frontend/src/pages/auth/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/auth/OAuthCallbackPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../../contexts/AuthContext'
 import { Flex, Spinner, Text, Card, Callout } from '@radix-ui/themes'
@@ -9,9 +9,14 @@ export const OAuthCallbackPage: React.FC = () => {
   const { handleOAuthCallback } = useAuth()
   const navigate = useNavigate()
   const [error, setError] = useState('')
+  const processingRef = useRef(false)
 
   useEffect(() => {
     const processCallback = async () => {
+      // Prevent duplicate processing (React strict mode causes double mount)
+      if (processingRef.current) return
+      processingRef.current = true
+
       const code = searchParams.get('code')
       const state = searchParams.get('state')
       const provider = window.location.pathname.includes('google') ? 'google' : 'github'

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../../contexts/AuthContext'
 import { Button, TextField, Checkbox, Text, Heading, Card, Flex, Callout, Progress, Separator } from '@radix-ui/themes'
 import { CheckIcon, ExclamationTriangleIcon } from '@radix-ui/react-icons'
+import { FeatureChecklist } from '../../components/auth/FeatureChecklist'
 
 export const RegisterPage: React.FC = () => {
   const [email, setEmail] = useState('')
@@ -165,7 +166,10 @@ export const RegisterPage: React.FC = () => {
             }}
           />
         </a>
-        <Card size="4" style={{ maxWidth: '400px', width: '100%' }}>
+        <div className="auth-layout">
+          <FeatureChecklist />
+          <div className="auth-form-container">
+            <Card size="4" style={{ maxWidth: '400px', width: '100%' }}>
           <Flex direction="column" gap="6">
             <Flex justify="center" align="center" style={{ width: '100%' }}>
               <a
@@ -261,6 +265,8 @@ export const RegisterPage: React.FC = () => {
             </Flex>
           </Flex>
         </Card>
+          </div>
+        </div>
       </div>
     )
   }
@@ -286,7 +292,10 @@ export const RegisterPage: React.FC = () => {
           }}
         />
       </a>
-      <Card size="4" style={{ maxWidth: '400px', width: '100%' }}>
+      <div className="auth-layout">
+        <FeatureChecklist />
+        <div className="auth-form-container">
+          <Card size="4" style={{ maxWidth: '400px', width: '100%' }}>
         <Flex direction="column" gap="2">
           <Flex justify="center" align="center" style={{ width: '100%' }}>
             <a
@@ -451,6 +460,8 @@ export const RegisterPage: React.FC = () => {
           </form>
         </Flex>
       </Card>
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../../contexts/AuthContext'
-import { Button, TextField, Checkbox, Text, Heading, Card, Flex, Callout, Progress } from '@radix-ui/themes'
+import { Button, TextField, Checkbox, Text, Heading, Card, Flex, Callout, Progress, Separator } from '@radix-ui/themes'
 import { CheckIcon, ExclamationTriangleIcon } from '@radix-ui/react-icons'
 
 export const RegisterPage: React.FC = () => {
@@ -16,7 +16,7 @@ export const RegisterPage: React.FC = () => {
   const [verificationToken, setVerificationToken] = useState('')
   const [verifyLoading, setVerifyLoading] = useState(false)
 
-  const { register, resendVerification, verify } = useAuth()
+  const { register, resendVerification, verify, loginWithGoogle, loginWithGithub } = useAuth()
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const returnTo = searchParams.get('returnTo') || '/dashboard'
@@ -108,6 +108,38 @@ export const RegisterPage: React.FC = () => {
       setError(err instanceof Error ? err.message : 'Verification failed')
     } finally {
       setVerifyLoading(false)
+    }
+  }
+
+  const handleGoogleLogin = async () => {
+    setError('')
+    setLoading(true)
+
+    try {
+      const returnToParam = returnTo !== '/dashboard' ? returnTo : undefined
+      if (returnToParam) {
+        sessionStorage.setItem('oauth_return_to', returnToParam)
+      }
+      await loginWithGoogle(returnToParam)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Google signup failed')
+      setLoading(false)
+    }
+  }
+
+  const handleGithubLogin = async () => {
+    setError('')
+    setLoading(true)
+
+    try {
+      const returnToParam = returnTo !== '/dashboard' ? returnTo : undefined
+      if (returnToParam) {
+        sessionStorage.setItem('oauth_return_to', returnToParam)
+      }
+      await loginWithGithub(returnToParam)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'GitHub signup failed')
+      setLoading(false)
     }
   }
 
@@ -371,15 +403,52 @@ export const RegisterPage: React.FC = () => {
               >
                 {loading ? 'Creating Account...' : 'Create Account'}
               </Button>
+
+              <Text size="2" color="gray" align="center">
+                Already have an account?{' '}
+                <Link to={`/login${returnTo !== '/dashboard' ? `?returnTo=${encodeURIComponent(returnTo)}` : ''}`} style={{ color: 'var(--accent-9)', textDecoration: 'none' }}>
+                  Sign in
+                </Link>
+              </Text>
+
+              <Flex align="center" gap="3" style={{ marginTop: '4px' }}>
+                <Separator size="4" style={{ flex: 1 }} />
+                <Text size="2" color="gray">or</Text>
+                <Separator size="4" style={{ flex: 1 }} />
+              </Flex>
+
+              <Button
+                type="button"
+                size="3"
+                variant="outline"
+                style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '8px' }}
+                onClick={handleGoogleLogin}
+                disabled={loading}
+              >
+                <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M17.64 9.20454C17.64 8.56636 17.5827 7.95272 17.4764 7.36363H9V10.845H13.8436C13.635 11.97 13.0009 12.9232 12.0477 13.5614V15.8195H14.9564C16.6582 14.2527 17.64 11.9454 17.64 9.20454Z" fill="#4285F4"/>
+                  <path d="M9 18C11.43 18 13.4673 17.1941 14.9564 15.8195L12.0477 13.5614C11.2418 14.1014 10.2109 14.4204 9 14.4204C6.65591 14.4204 4.67182 12.8373 3.96409 10.71H0.957275V13.0418C2.43818 15.9832 5.48182 18 9 18Z" fill="#34A853"/>
+                  <path d="M3.96409 10.71C3.78409 10.17 3.68182 9.59318 3.68182 9C3.68182 8.40682 3.78409 7.83 3.96409 7.29V4.95818H0.957275C0.347727 6.17318 0 7.54773 0 9C0 10.4523 0.347727 11.8268 0.957275 13.0418L3.96409 10.71Z" fill="#FBBC05"/>
+                  <path d="M9 3.57955C10.3214 3.57955 11.5077 4.03364 12.4405 4.92545L15.0218 2.34409C13.4632 0.891818 11.4259 0 9 0C5.48182 0 2.43818 2.01682 0.957275 4.95818L3.96409 7.29C4.67182 5.16273 6.65591 3.57955 9 3.57955Z" fill="#EA4335"/>
+                </svg>
+                Continue with Google
+              </Button>
+
+              <Button
+                type="button"
+                size="3"
+                variant="outline"
+                style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '8px' }}
+                onClick={handleGithubLogin}
+                disabled={loading}
+              >
+                <svg width="18" height="18" viewBox="0 0 98 96" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                  <path fillRule="evenodd" clipRule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"/>
+                </svg>
+                Continue with GitHub
+              </Button>
             </Flex>
           </form>
-
-          <Text size="2" color="gray" align="center">
-            Already have an account?{' '}
-            <Link to={`/login${returnTo !== '/dashboard' ? `?returnTo=${encodeURIComponent(returnTo)}` : ''}`} style={{ color: 'var(--accent-9)', textDecoration: 'none' }}>
-              Sign in
-            </Link>
-          </Text>
         </Flex>
       </Card>
     </div>

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -48,13 +48,18 @@ export const RegisterPage: React.FC = () => {
     e.preventDefault()
     setError('')
 
-    if (password !== confirmPassword) {
-      setError('Passwords do not match')
+    if (!email.trim()) {
+      setError('Please enter your email')
       return
     }
 
     if (password.length < 8) {
       setError('Password must be at least 8 characters')
+      return
+    }
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match')
       return
     }
 
@@ -169,7 +174,7 @@ export const RegisterPage: React.FC = () => {
         <div className="auth-layout">
           <FeatureChecklist />
           <div className="auth-form-container">
-            <Card size="4" style={{ maxWidth: '400px', width: '100%' }}>
+            <Card size="4" style={{ width: '480px' }}>
           <Flex direction="column" gap="6">
             <Flex justify="center" align="center" style={{ width: '100%' }}>
               <a
@@ -205,7 +210,7 @@ export const RegisterPage: React.FC = () => {
               >
                 <CheckIcon width="32" height="32" />
               </Flex>
-              <Heading size="6">Account Created!</Heading>
+              <Heading size="8">Account Created!</Heading>
               <Text size="2" color="gray" align="center">
                 We've sent a verification email to <Text weight="bold">{email}</Text>.
                 Please enter the verification token below to complete your account setup.
@@ -258,7 +263,7 @@ export const RegisterPage: React.FC = () => {
 
               <Text size="2" color="gray" align="center">
                 Need help?{' '}
-                <Link to="/support" style={{ color: 'var(--accent-9)', textDecoration: 'none' }}>
+                <Link to="/support" className="auth-link">
                   Contact support
                 </Link>
               </Text>
@@ -295,7 +300,7 @@ export const RegisterPage: React.FC = () => {
       <div className="auth-layout">
         <FeatureChecklist />
         <div className="auth-form-container">
-          <Card size="4" style={{ maxWidth: '400px', width: '100%' }}>
+          <Card size="4" style={{ width: '480px' }}>
         <Flex direction="column" gap="2">
           <Flex justify="center" align="center" style={{ width: '100%' }}>
             <a
@@ -318,36 +323,42 @@ export const RegisterPage: React.FC = () => {
           </Flex>
 
           <Flex direction="column" gap="2" align="center">
-            <Heading size="6">Create Account</Heading>
-            <Text size="2" color="gray">
+            <Heading size="8">Create Account</Heading>
+            <Text size="4" color="gray">
               Get started with Shinzo
             </Text>
           </Flex>
 
+          <div style={{ height: '24px' }} />
+
           <form onSubmit={handleSubmit}>
             <Flex direction="column" gap="4">
-              <Flex direction="column" gap="2">
-                <Text size="2" weight="medium">Email</Text>
+              <Flex align="center" gap="3">
+                <Text size="2" weight="medium" style={{ width: '80px', flexShrink: 0 }}>Email</Text>
                 <TextField.Root
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="Enter your email"
                   required
+                  style={{ flex: 1 }}
                 />
               </Flex>
 
               <Flex direction="column" gap="2">
-                <Text size="2" weight="medium">Password</Text>
-                <TextField.Root
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  placeholder="Create a password"
-                  required
-                />
+                <Flex align="center" gap="3">
+                  <Text size="2" weight="medium" style={{ width: '80px', flexShrink: 0 }}>Password</Text>
+                  <TextField.Root
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="Create a password"
+                    required
+                    style={{ flex: 1 }}
+                  />
+                </Flex>
                 {password && (
-                  <Flex direction="column" gap="1">
+                  <Flex direction="column" gap="1" style={{ marginLeft: '92px' }}>
                     <Progress
                       value={(passwordStrength / 5) * 100}
                       color={passwordStrengthColors[passwordStrength - 1] as any}
@@ -361,16 +372,19 @@ export const RegisterPage: React.FC = () => {
               </Flex>
 
               <Flex direction="column" gap="2">
-                <Text size="2" weight="medium">Confirm Password</Text>
-                <TextField.Root
-                  type="password"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  placeholder="Confirm your password"
-                  required
-                />
+                <Flex align="center" gap="3">
+                  <Text size="2" weight="medium" style={{ width: '80px', flexShrink: 0 }}>Confirm</Text>
+                  <TextField.Root
+                    type="password"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    placeholder="Confirm your password"
+                    required
+                    style={{ flex: 1 }}
+                  />
+                </Flex>
                 {confirmPassword && password !== confirmPassword && (
-                  <Text size="1" color="red">
+                  <Text size="1" color="red" style={{ marginLeft: '92px' }}>
                     Passwords must match
                   </Text>
                 )}
@@ -385,11 +399,11 @@ export const RegisterPage: React.FC = () => {
                 />
                 <Text size="2" color="gray">
                   I agree to the{' '}
-                  <a href="https://www.shinzo.ai/terms" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent-9)', textDecoration: 'none' }}>
+                  <a href="https://www.shinzo.ai/terms" target="_blank" rel="noopener noreferrer" className="auth-link">
                     Terms of Service
                   </a>{' '}
                   and{' '}
-                  <a href="https://www.shinzo.ai/privacy" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent-9)', textDecoration: 'none' }}>
+                  <a href="https://www.shinzo.ai/privacy" target="_blank" rel="noopener noreferrer" className="auth-link">
                     Privacy Policy
                   </a>
                 </Text>
@@ -408,14 +422,14 @@ export const RegisterPage: React.FC = () => {
                 type="submit"
                 size="3"
                 style={{ width: '100%' }}
-                disabled={loading || !isFormValid}
+                disabled={loading}
               >
                 {loading ? 'Creating Account...' : 'Create Account'}
               </Button>
 
               <Text size="2" color="gray" align="center">
                 Already have an account?{' '}
-                <Link to={`/login${returnTo !== '/dashboard' ? `?returnTo=${encodeURIComponent(returnTo)}` : ''}`} style={{ color: 'var(--accent-9)', textDecoration: 'none' }}>
+                <Link to={`/login${returnTo !== '/dashboard' ? `?returnTo=${encodeURIComponent(returnTo)}` : ''}`} className="auth-link">
                   Sign in
                 </Link>
               </Text>
@@ -426,38 +440,49 @@ export const RegisterPage: React.FC = () => {
                 <Separator size="4" style={{ flex: 1 }} />
               </Flex>
 
-              <Button
-                type="button"
-                size="3"
-                variant="outline"
-                style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '8px' }}
-                onClick={handleGoogleLogin}
-                disabled={loading}
-              >
-                <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17.64 9.20454C17.64 8.56636 17.5827 7.95272 17.4764 7.36363H9V10.845H13.8436C13.635 11.97 13.0009 12.9232 12.0477 13.5614V15.8195H14.9564C16.6582 14.2527 17.64 11.9454 17.64 9.20454Z" fill="#4285F4"/>
-                  <path d="M9 18C11.43 18 13.4673 17.1941 14.9564 15.8195L12.0477 13.5614C11.2418 14.1014 10.2109 14.4204 9 14.4204C6.65591 14.4204 4.67182 12.8373 3.96409 10.71H0.957275V13.0418C2.43818 15.9832 5.48182 18 9 18Z" fill="#34A853"/>
-                  <path d="M3.96409 10.71C3.78409 10.17 3.68182 9.59318 3.68182 9C3.68182 8.40682 3.78409 7.83 3.96409 7.29V4.95818H0.957275C0.347727 6.17318 0 7.54773 0 9C0 10.4523 0.347727 11.8268 0.957275 13.0418L3.96409 10.71Z" fill="#FBBC05"/>
-                  <path d="M9 3.57955C10.3214 3.57955 11.5077 4.03364 12.4405 4.92545L15.0218 2.34409C13.4632 0.891818 11.4259 0 9 0C5.48182 0 2.43818 2.01682 0.957275 4.95818L3.96409 7.29C4.67182 5.16273 6.65591 3.57955 9 3.57955Z" fill="#EA4335"/>
-                </svg>
-                Continue with Google
-              </Button>
+              <Flex gap="3">
+                <Button
+                  type="button"
+                  size="3"
+                  variant="outline"
+                  style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                  onClick={handleGoogleLogin}
+                  disabled={loading}
+                >
+                  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M17.64 9.20454C17.64 8.56636 17.5827 7.95272 17.4764 7.36363H9V10.845H13.8436C13.635 11.97 13.0009 12.9232 12.0477 13.5614V15.8195H14.9564C16.6582 14.2527 17.64 11.9454 17.64 9.20454Z" fill="#4285F4"/>
+                    <path d="M9 18C11.43 18 13.4673 17.1941 14.9564 15.8195L12.0477 13.5614C11.2418 14.1014 10.2109 14.4204 9 14.4204C6.65591 14.4204 4.67182 12.8373 3.96409 10.71H0.957275V13.0418C2.43818 15.9832 5.48182 18 9 18Z" fill="#34A853"/>
+                    <path d="M3.96409 10.71C3.78409 10.17 3.68182 9.59318 3.68182 9C3.68182 8.40682 3.78409 7.83 3.96409 7.29V4.95818H0.957275C0.347727 6.17318 0 7.54773 0 9C0 10.4523 0.347727 11.8268 0.957275 13.0418L3.96409 10.71Z" fill="#FBBC05"/>
+                    <path d="M9 3.57955C10.3214 3.57955 11.5077 4.03364 12.4405 4.92545L15.0218 2.34409C13.4632 0.891818 11.4259 0 9 0C5.48182 0 2.43818 2.01682 0.957275 4.95818L3.96409 7.29C4.67182 5.16273 6.65591 3.57955 9 3.57955Z" fill="#EA4335"/>
+                  </svg>
+                </Button>
 
-              <Button
-                type="button"
-                size="3"
-                variant="outline"
-                style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '8px' }}
-                onClick={handleGithubLogin}
-                disabled={loading}
-              >
-                <svg width="18" height="18" viewBox="0 0 98 96" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                  <path fillRule="evenodd" clipRule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"/>
-                </svg>
-                Continue with GitHub
-              </Button>
+                <Button
+                  type="button"
+                  size="3"
+                  variant="outline"
+                  style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                  onClick={handleGithubLogin}
+                  disabled={loading}
+                >
+                  <svg width="18" height="18" viewBox="0 0 98 96" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                    <path fillRule="evenodd" clipRule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"/>
+                  </svg>
+                </Button>
+              </Flex>
             </Flex>
           </form>
+
+          <Flex justify="center" gap="2" style={{ marginTop: '16px' }}>
+            <a href="https://www.shinzo.ai/terms" target="_blank" rel="noopener noreferrer" className="auth-link" style={{ fontSize: '12px' }}>
+              Terms of Service
+            </a>
+            <Text size="1" color="gray">•</Text>
+            <a href="https://www.shinzo.ai/privacy" target="_blank" rel="noopener noreferrer" className="auth-link" style={{ fontSize: '12px' }}>
+              Privacy Policy
+            </a>
+          </Flex>
+
         </Flex>
       </Card>
         </div>


### PR DESCRIPTION
## Summary
Restructured the authentication pages to provide a unified, streamlined login and registration experience. Removed the toggle-based dual-mode login interface and integrated OAuth options (Google and GitHub) directly into both the login and registration flows.

## Key Changes

**LoginPage.tsx:**
- Removed `loginMode` state and conditional rendering that toggled between OAuth and email login modes
- Consolidated the form to always display email/password login as the primary method
- Moved OAuth buttons (Google, GitHub) below the email login form with a visual separator
- Added a "Don't have an account?" link to the registration page
- Improved UX by presenting all authentication options in a single, linear flow

**RegisterPage.tsx:**
- Added OAuth login handlers (`handleGoogleLogin`, `handleGithubLogin`) to enable social signup
- Integrated Google and GitHub buttons into the registration form flow
- Added "Already have an account?" link to the login page
- Imported `Separator` component for consistent visual dividers
- Positioned OAuth options after the account creation button with an "or" separator

## Implementation Details
- Both pages now follow a consistent pattern: primary auth method (email) → separator → OAuth alternatives
- OAuth handlers properly manage the `returnTo` parameter via `sessionStorage` for post-auth redirects
- Links between login and registration pages preserve the `returnTo` query parameter for seamless navigation
- Removed unnecessary state management, simplifying component logic
- Visual hierarchy improved with clearer separation between authentication methods

https://claude.ai/code/session_016WCoCzyAsMmRWch5KwjRhd