### PR TITLE
Update onboarding flow for AI Analytics

### DIFF
--- a/backend/src/handlers/spotlight.ts
+++ b/backend/src/handlers/spotlight.ts
@@ -492,6 +492,26 @@ export const handleModelProxy = async (
     const { apiKeyUuid, userUuid } = shinzoCredentials
     const { providerKeyUuid, authType } = providerCredentials
 
+    // Block subscription-based access (OAuth tokens from Claude subscriptions)
+    // This is temporarily disabled due to unclear terms and conditions with Anthropic's API
+    if (authType === 'subscription') {
+      logger.warn({
+        message: 'Subscription-based access blocked',
+        userUuid,
+        authType
+      })
+      return {
+        response: {
+          error: {
+            type: 'subscription_not_supported',
+            message: 'Shinzo Platform is currently only compatible with API key-based access. Please add your Anthropic API key in the settings page to continue. Subscription-based access (using Claude subscription OAuth tokens) is not supported at this time.'
+          }
+        },
+        error: true,
+        status: 403
+      }
+    }
+
     let session: any = null
     const sessionId = requestBody.metadata?.user_id || 'default-session'
 
@@ -798,6 +818,26 @@ export const handleCountTokens = async (
   try {
     const { apiKeyUuid, userUuid } = shinzoCredentials
     const { providerKeyUuid, authType } = providerCredentials
+
+    // Block subscription-based access (OAuth tokens from Claude subscriptions)
+    if (authType === 'subscription') {
+      logger.warn({
+        message: 'Subscription-based access blocked for count tokens',
+        userUuid,
+        authType
+      })
+      return {
+        response: {
+          error: {
+            type: 'subscription_not_supported',
+            message: 'Shinzo Platform is currently only compatible with API key-based access. Please add your Anthropic API key in the settings page to continue. Subscription-based access (using Claude subscription OAuth tokens) is not supported at this time.'
+          }
+        },
+        error: true,
+        status: 403
+      }
+    }
+
     const requestTimestamp = new Date()
     const messageCount = requestBody.messages?.length || 0
     const hasSystemPrompt = !!requestBody.system
@@ -910,7 +950,27 @@ export const handleEventLogging = async (
 ) => {
   try {
     const { apiKeyUuid, userUuid } = shinzoCredentials
-    
+    const { authType } = providerCredentials
+
+    // Block subscription-based access (OAuth tokens from Claude subscriptions)
+    if (authType === 'subscription') {
+      logger.warn({
+        message: 'Subscription-based access blocked for event logging',
+        userUuid,
+        authType
+      })
+      return {
+        response: {
+          error: {
+            type: 'subscription_not_supported',
+            message: 'Shinzo Platform is currently only compatible with API key-based access. Please add your Anthropic API key in the settings page to continue. Subscription-based access (using Claude subscription OAuth tokens) is not supported at this time.'
+          }
+        },
+        error: true,
+        status: 403
+      }
+    }
+
     const headers = constructModelAPIHeaders(requestHeaders)
 
     const url = `${modelProviderBaseURL[provider]}${modelAPISpec[provider].eventLogging}`

--- a/frontend/src/components/InitialQuestionnaireDialog.tsx
+++ b/frontend/src/components/InitialQuestionnaireDialog.tsx
@@ -20,19 +20,19 @@ export const InitialQuestionnaireDialog: React.FC<InitialQuestionnaireDialogProp
     hideRequiredBadge: true, // All questions are required, so no need to show the badge
     questions: [
       {
-        id: 'usage_types',
-        type: 'multi-select',
-        question: 'What would you like to do with Shinzo?',
-        description: 'Select all that apply.',
+        id: 'usage_type',
+        type: 'single-select-radio',
+        question: 'Which type of analytics do you want to use first?',
+        description: "Don't worry — you can always switch to the other option later in the onboarding flow.",
         required: true,
         options: [
           {
-            label: 'Track AI Agent usage',
+            label: 'AI Agent Analytics',
             value: 'ai-agent',
             description: 'Monitor Claude API usage, token consumption, and agent interactions.'
           },
           {
-            label: 'Track MCP Server usage',
+            label: 'MCP Server Analytics',
             value: 'mcp-server',
             description: 'Monitor MCP server telemetry, traces, spans, and metrics.'
           },
@@ -108,15 +108,18 @@ export const InitialQuestionnaireDialog: React.FC<InitialQuestionnaireDialogProp
       return option?.label || value
     }
 
-    // Transform usage_types to display text
-    const usage_types_values = answers.usage_types as string[] || []
-    const usage_types = usage_types_values.map(value => {
-      // If "Something Else" is selected and has custom text, use that instead
-      if (value === 'something-else' && answers['usage_types_text']) {
-        return answers['usage_types_text'] as string
+    // Store usage_type raw value for routing, with custom text fallback
+    const usage_type_value = answers.usage_type as string || ''
+    let usage_types: string[] = []
+    if (usage_type_value) {
+      // If "Something Else" is selected and has custom text, use that text
+      if (usage_type_value === 'something-else' && answers['usage_type_text']) {
+        usage_types = [answers['usage_type_text'] as string]
+      } else {
+        // Store the raw value ('ai-agent' or 'mcp-server') for routing
+        usage_types = [usage_type_value]
       }
-      return getLabel('usage_types', value)
-    })
+    }
 
     // Transform role to display text
     const role_value = answers.role as string

--- a/frontend/src/pages/GettingStartedPage.tsx
+++ b/frontend/src/pages/GettingStartedPage.tsx
@@ -187,8 +187,6 @@ async def shutdown():
         <OnboardingHeader
           title="Getting Started"
           description="Set up your MCP server with Shinzo Platform in under 60 seconds"
-          successMessage="Your ingest token has been automatically generated! Copy the code below and start sending telemetry data."
-          showSuccess={!!ingestToken}
           videoUrl="https://www.youtube.com/embed/ngv4QTURY6c"
           videoTitle="Get Onboarded to the Shinzo Analytics Platform in 60 Seconds or Less"
         />

--- a/frontend/src/pages/GettingStartedPage.tsx
+++ b/frontend/src/pages/GettingStartedPage.tsx
@@ -13,9 +13,11 @@ type SdkType = 'typescript' | 'python-mcp' | 'python-fastmcp'
 export const GettingStartedPage: React.FC = () => {
   const { token } = useAuth()
   const [ingestToken, setIngestToken] = useState<string>('')
+  const [ingestTokenUuid, setIngestTokenUuid] = useState<string>('')
   const [loading, setLoading] = useState(true)
   const [hasTelemetry, setHasTelemetry] = useState(false)
   const [sdkType, setSdkType] = useState<SdkType>('typescript')
+  const [regeneratingToken, setRegeneratingToken] = useState(false)
 
   useEffect(() => {
     const fetchIngestToken = async () => {
@@ -23,6 +25,7 @@ export const GettingStartedPage: React.FC = () => {
         const tokens = await ingestTokenService.fetchAll(token!)
         if (tokens.length > 0) {
           setIngestToken(tokens[0].ingest_token)
+          setIngestTokenUuid(tokens[0].uuid)
         }
       } catch (error) {
         console.error('Failed to fetch ingest token:', error)
@@ -35,6 +38,25 @@ export const GettingStartedPage: React.FC = () => {
       fetchIngestToken()
     }
   }, [token])
+
+  const handleRegenerateIngestToken = async () => {
+    setRegeneratingToken(true)
+    try {
+      // Revoke the old token
+      if (ingestTokenUuid) {
+        await ingestTokenService.revoke(token!, ingestTokenUuid)
+      }
+
+      // Generate a new token
+      const newToken = await ingestTokenService.generate(token!)
+      setIngestToken(newToken.token)
+      setIngestTokenUuid(newToken.uuid)
+    } catch (error) {
+      console.error('Failed to regenerate ingest token:', error)
+    } finally {
+      setRegeneratingToken(false)
+    }
+  }
 
   // Poll for telemetry data every 5 seconds
   useEffect(() => {
@@ -264,21 +286,39 @@ async def shutdown():
           title="Add Telemetry to Your Server"
           description="Import and initialize Shinzo instrumentation in your MCP server"
         >
-          <CodeSnippet
-            code={getCurrentSnippet()}
-            copyId="code-snippet"
-          />
+          <Flex direction="column" gap="3">
+            {ingestToken && (
+              <Flex align="center" gap="2">
+                <Text size="2" weight="medium">Ingest Token:</Text>
+                <Text size="2" style={{ fontFamily: 'monospace' }}>{ingestToken.substring(0, 20)}...</Text>
+                <Button
+                  size="1"
+                  variant="ghost"
+                  onClick={handleRegenerateIngestToken}
+                  disabled={regeneratingToken}
+                  style={{ cursor: 'pointer' }}
+                >
+                  {regeneratingToken ? <Spinner size="1" /> : <Icons.ReloadIcon />}
+                </Button>
+              </Flex>
+            )}
 
-          {!ingestToken && (
-            <Callout.Root color="amber">
-              <Callout.Icon>
-                <Icons.ExclamationTriangleIcon />
-              </Callout.Icon>
-              <Callout.Text>
-                No ingest token found. Generate one in Settings → Ingest Tokens.
-              </Callout.Text>
-            </Callout.Root>
-          )}
+            <CodeSnippet
+              code={getCurrentSnippet()}
+              copyId="code-snippet"
+            />
+
+            {!ingestToken && (
+              <Callout.Root color="amber">
+                <Callout.Icon>
+                  <Icons.ExclamationTriangleIcon />
+                </Callout.Icon>
+                <Callout.Text>
+                  No ingest token found. Generate one in Settings → Ingest Tokens.
+                </Callout.Text>
+              </Callout.Root>
+            )}
+          </Flex>
         </OnboardingStep>
 
         {/* Step 4: Run and verify */}

--- a/frontend/src/pages/spotlight/SpotlightGettingStartedPage.tsx
+++ b/frontend/src/pages/spotlight/SpotlightGettingStartedPage.tsx
@@ -263,8 +263,6 @@ print(message.content)`
         <OnboardingHeader
           title="AI Analytics Setup"
           description="Connect your AI application to start tracking usage, costs, and performance"
-          successMessage="Your Shinzo API key has been automatically generated! Follow the steps below to start sending analytics data."
-          showSuccess={!!shinzoApiKey}
         />
 
         {/* Step 1: Enter Your Anthropic API Key */}

--- a/frontend/src/pages/spotlight/SpotlightGettingStartedPage.tsx
+++ b/frontend/src/pages/spotlight/SpotlightGettingStartedPage.tsx
@@ -23,7 +23,7 @@ export const SpotlightGettingStartedPage: React.FC = () => {
   const [loading, setLoading] = useState(true)
   const { hasSpotlightData } = useHasSpotlightData()
   const [sdkType, setSdkType] = useState<SdkType>('typescript')
-  const [configMethod, setConfigMethod] = useState<ConfigMethod>('env-vars')
+  const [configMethod, setConfigMethod] = useState<ConfigMethod>('library-params')
 
   // Provider API key state
   const [providerApiKey, setProviderApiKey] = useState<string>('')
@@ -558,11 +558,23 @@ print(message.content)`
 
                 <Tabs.Root value={configMethod} onValueChange={(value) => setConfigMethod(value as ConfigMethod)}>
                   <Tabs.List>
+                    <Tabs.Trigger value="library-params" style={{ cursor: 'pointer' }}>Class Params (Recommended)</Tabs.Trigger>
                     <Tabs.Trigger value="env-vars" style={{ cursor: 'pointer' }}>Environment Variables</Tabs.Trigger>
-                    <Tabs.Trigger value="library-params" style={{ cursor: 'pointer' }}>Library Parameters</Tabs.Trigger>
                   </Tabs.List>
 
                   <Flex direction="column" gap="3" style={{ marginTop: '16px' }}>
+                    <Tabs.Content value="library-params">
+                      <Flex direction="column" gap="3">
+                        <Text size="2" color="gray">
+                          Pass the configuration directly to the SDK constructor:
+                        </Text>
+                        <CodeSnippet
+                          code={sdkType === 'typescript' ? libraryParamsTypescript : libraryParamsPython}
+                          copyId="library-params-code"
+                        />
+                      </Flex>
+                    </Tabs.Content>
+
                     <Tabs.Content value="env-vars">
                       <Flex direction="column" gap="3">
                         <Text size="2" color="gray">
@@ -575,18 +587,6 @@ print(message.content)`
                         <CodeSnippet
                           code={sdkType === 'typescript' ? envVarsCodeTypescript : envVarsCodePython}
                           copyId="env-vars-code"
-                        />
-                      </Flex>
-                    </Tabs.Content>
-
-                    <Tabs.Content value="library-params">
-                      <Flex direction="column" gap="3">
-                        <Text size="2" color="gray">
-                          Pass the configuration directly to the SDK constructor:
-                        </Text>
-                        <CodeSnippet
-                          code={sdkType === 'typescript' ? libraryParamsTypescript : libraryParamsPython}
-                          copyId="library-params-code"
                         />
                       </Flex>
                     </Tabs.Content>

--- a/frontend/src/pages/spotlight/SpotlightGettingStartedPage.tsx
+++ b/frontend/src/pages/spotlight/SpotlightGettingStartedPage.tsx
@@ -611,6 +611,29 @@ print(message.content)`
                 copyId="run-claude"
                 inline
               />
+              <Callout.Root color="blue">
+                <Callout.Icon>
+                  <Icons.InfoCircledIcon />
+                </Callout.Icon>
+                <Callout.Text>
+                  <Text size="2" weight="medium" style={{ display: 'block', marginBottom: '8px' }}>
+                    You'll see several login screens. Follow these steps:
+                  </Text>
+                  <Flex direction="column" gap="2" style={{ paddingLeft: '8px' }}>
+                    <Text size="2">
+                      1. When prompted to choose a login method, select{' '}
+                      <Text weight="medium" style={{ fontFamily: 'monospace' }}>2. Anthropic Console account · API usage billing</Text>
+                    </Text>
+                    <Text size="2">
+                      2. When you see "Detected a custom API key in your environment... Do you want to use this API key?", select{' '}
+                      <Text weight="medium" style={{ fontFamily: 'monospace' }}>No (Recommended)</Text>
+                    </Text>
+                    <Text size="2">
+                      3. You may need to restart <Text style={{ fontFamily: 'monospace' }}>claude</Text> after completing login for Shinzo observability to take effect.
+                    </Text>
+                  </Flex>
+                </Callout.Text>
+              </Callout.Root>
             </Flex>
           )}
           <Flex direction="column" gap="2" style={{ paddingLeft: '20px', marginTop: selectedIntegration === 'claude-code' ? '16px' : '0' }}>

--- a/frontend/src/pages/spotlight/SpotlightGettingStartedPage.tsx
+++ b/frontend/src/pages/spotlight/SpotlightGettingStartedPage.tsx
@@ -622,11 +622,11 @@ print(message.content)`
                   <Flex direction="column" gap="2" style={{ paddingLeft: '8px' }}>
                     <Text size="2">
                       1. When prompted to choose a login method, select{' '}
-                      <Text weight="medium" style={{ fontFamily: 'monospace' }}>2. Anthropic Console account · API usage billing</Text>
+                      <Text weight="medium" style={{ fontFamily: 'monospace' }}> "Anthropic Console account · API usage billing"</Text>
                     </Text>
                     <Text size="2">
-                      2. When you see "Detected a custom API key in your environment... Do you want to use this API key?", select{' '}
-                      <Text weight="medium" style={{ fontFamily: 'monospace' }}>No (Recommended)</Text>
+                      2. If you see "Detected a custom API key in your environment... Do you want to use this API key?", select{' '}
+                      <Text weight="medium" style={{ fontFamily: 'monospace' }}> "No (Recommended)"</Text>
                     </Text>
                     <Text size="2">
                       3. You may need to restart <Text style={{ fontFamily: 'monospace' }}>claude</Text> after completing login for Shinzo observability to take effect.
@@ -639,11 +639,11 @@ print(message.content)`
           <Flex direction="column" gap="2" style={{ paddingLeft: '20px', marginTop: selectedIntegration === 'claude-code' ? '16px' : '0' }}>
             <Flex align="center" gap="2">
               <Icons.CheckIcon color="var(--green-9)" />
-              <Text size="2">Claude API requests are made</Text>
+              <Text size="2">Claude API requests are made to Shinzo with Shinzo platform API Key in a custom header</Text>
             </Flex>
             <Flex align="center" gap="2">
               <Icons.CheckIcon color="var(--green-9)" />
-              <Text size="2">Analytics data is sent to Shinzo</Text>
+              <Text size="2">Analytics data is recorded, and the request is repackaged with the stored API key</Text>
             </Flex>
             <Flex align="center" gap="2">
               <Icons.CheckIcon color="var(--green-9)" />

--- a/frontend/src/pages/spotlight/SpotlightGettingStartedPage.tsx
+++ b/frontend/src/pages/spotlight/SpotlightGettingStartedPage.tsx
@@ -155,17 +155,17 @@ export const SpotlightGettingStartedPage: React.FC = () => {
     }
   }
 
-  // Claude Code setup - using ANTHROPIC_API_KEY instead of custom headers
-  const claudeCodeSetupMacOS = `echo 'export ANTHROPIC_API_KEY="${shinzoApiKey}"' >> ~/.zshrc
-echo 'export ANTHROPIC_BASE_URL="${BACKEND_URL}/spotlight/anthropic"' >> ~/.zshrc
+  // Claude Code setup - using custom headers for Shinzo API key
+  const claudeCodeSetupMacOS = `echo 'export ANTHROPIC_BASE_URL="${BACKEND_URL}/spotlight/anthropic"' >> ~/.zshrc
+echo 'export ANTHROPIC_CUSTOM_HEADERS="x-shinzo-api-key: ${shinzoApiKey}"' >> ~/.zshrc
 source ~/.zshrc`
 
-  const claudeCodeSetupLinux = `echo 'export ANTHROPIC_API_KEY="${shinzoApiKey}"' >> ~/.bashrc
-echo 'export ANTHROPIC_BASE_URL="${BACKEND_URL}/spotlight/anthropic"' >> ~/.bashrc
+  const claudeCodeSetupLinux = `echo 'export ANTHROPIC_BASE_URL="${BACKEND_URL}/spotlight/anthropic"' >> ~/.bashrc
+echo 'export ANTHROPIC_CUSTOM_HEADERS="x-shinzo-api-key: ${shinzoApiKey}"' >> ~/.bashrc
 source ~/.bashrc`
 
-  const claudeCodeSetupWindows = `[System.Environment]::SetEnvironmentVariable('ANTHROPIC_API_KEY', '${shinzoApiKey}', 'User')
-[System.Environment]::SetEnvironmentVariable('ANTHROPIC_BASE_URL', '${BACKEND_URL}/spotlight/anthropic', 'User')`
+  const claudeCodeSetupWindows = `[System.Environment]::SetEnvironmentVariable('ANTHROPIC_BASE_URL', '${BACKEND_URL}/spotlight/anthropic', 'User')
+[System.Environment]::SetEnvironmentVariable('ANTHROPIC_CUSTOM_HEADERS', 'x-shinzo-api-key: ${shinzoApiKey}', 'User')`
 
   // Anthropic SDK - Environment variables setup
   const envVarsSetup = `export ANTHROPIC_API_KEY="${shinzoApiKey}"


### PR DESCRIPTION
## Summary
- Change analytics survey from multi-select to single-select with updated wording: "Which type of analytics do you want to use first?"
- Add note that users can switch analytics types later in onboarding
- Add provider API key entry step during AI Analytics onboarding, requiring users to enter and verify their Anthropic API key
- Block subscription-based access (OAuth tokens) in model proxy endpoints, returning 403 error with clear message

## Test plan
- [ ] Verify survey displays as single-select radio buttons with new wording
- [ ] Verify "Don't worry" note appears below the question
- [ ] Verify AI Analytics onboarding shows new Step 2 for API key entry
- [ ] Verify API key test and save flow works correctly
- [ ] Verify users with existing provider keys see success state on page load
- [ ] Verify subscription-based requests return 403 with appropriate error message
- [ ] Verify step numbers are correct for both Claude Code and Anthropic SDK paths

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)